### PR TITLE
Fix words not properly being counted

### DIFF
--- a/js/text-limiter.js
+++ b/js/text-limiter.js
@@ -31,10 +31,10 @@ jQuery( function ( $ ) {
 
 			this.$input.on( 'input', function () {
 				var value = this.value,
-					length = that.count( value, this.type );
+					length = that.count( value, that.type );
 
 				if ( length > that.max ) {
-					value = that.subStr( value, 0, that.max, this.type );
+					value = that.subStr( value, 0, that.max, that.type );
 					length = that.max;
 					this.value = value;
 				}


### PR DESCRIPTION
When using limit_type="word" the view looks proper but it still only counts by character. This is because there was a reference to `this` instead of `that`.

To reproduce:

1. Install the plugin
2. Create meta box
3. Set `'limit' => 10,` and `'limit_type' => 'word'`
4. Save and in the administration panel try and add `a great day at the park`.

Expected Results:
Word Count: 6/10

Actual Results:
![image](https://user-images.githubusercontent.com/17486071/60919983-1ccb6880-a265-11e9-97fe-2d6d35c59ece.png)